### PR TITLE
Support for 0.17 jaxrs-analyzer version, implementation dependencies support, output file basename supportGrimmjo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ version = '0.2'
 
 dependencies {
     compile gradleApi()
-    compile 'com.sebastian-daschner:jaxrs-analyzer:0.16'
+    compile 'com.sebastian-daschner:jaxrs-analyzer:0.17'
 }
 
 task sourcesJar(type: Jar, dependsOn: classes) {

--- a/src/main/groovy/com/github/grimmjo/jaxrs_analyzer/gradle/JaxRsAnalyzerExtension.groovy
+++ b/src/main/groovy/com/github/grimmjo/jaxrs_analyzer/gradle/JaxRsAnalyzerExtension.groovy
@@ -7,7 +7,7 @@ class JaxRsAnalyzerExtension {
 
     String[] backend = ['swagger']
     String outputDirectory
-
+    String outputFileBaseName
     String[] schemes = ['http']
     String domain = ''
     Boolean renderTags = false

--- a/src/main/groovy/com/github/grimmjo/jaxrs_analyzer/gradle/JaxRsAnalyzerTask.groovy
+++ b/src/main/groovy/com/github/grimmjo/jaxrs_analyzer/gradle/JaxRsAnalyzerTask.groovy
@@ -29,7 +29,7 @@ class JaxRsAnalyzerTask extends DefaultTask {
     void analyze() {
 
         Set<Path> classPaths = new HashSet<>()
-        project.configurations.implementation.each {
+        project.configurations.compileClasspath.each {
             classPaths.add(it.toPath())
         }
         project.configurations.compile.each {

--- a/src/main/groovy/com/github/grimmjo/jaxrs_analyzer/gradle/JaxRsAnalyzerTask.groovy
+++ b/src/main/groovy/com/github/grimmjo/jaxrs_analyzer/gradle/JaxRsAnalyzerTask.groovy
@@ -55,7 +55,7 @@ class JaxRsAnalyzerTask extends DefaultTask {
         project.jaxRsAnalyzer.backend.each {
             final Backend backend = JAXRSAnalyzer.constructBackend(it)
             backend.configure(config)
-            String outputFileBaseName = project.jaxRsAnalyzer.outputFileBaseName == null ? rest-resources : project.jaxRsAnalyzer.outputFileBaseName
+            String outputFileBaseName = project.jaxRsAnalyzer.outputFileBaseName == null ? 'rest-resources' : project.jaxRsAnalyzer.outputFileBaseName
             File outputFile = null
             switch (it) {
                 case 'swagger':

--- a/src/main/groovy/com/github/grimmjo/jaxrs_analyzer/gradle/JaxRsAnalyzerTask.groovy
+++ b/src/main/groovy/com/github/grimmjo/jaxrs_analyzer/gradle/JaxRsAnalyzerTask.groovy
@@ -15,6 +15,7 @@ import java.util.stream.Stream
 /**
  *
  * @author grimmjo
+ * @author finrod2002
  */
 class JaxRsAnalyzerTask extends DefaultTask {
 
@@ -28,6 +29,9 @@ class JaxRsAnalyzerTask extends DefaultTask {
     void analyze() {
 
         Set<Path> classPaths = new HashSet<>()
+        project.configurations.implementation.each {
+            classPaths.add(it.toPath())
+        }
         project.configurations.compile.each {
             classPaths.add(it.toPath())
         }
@@ -51,16 +55,17 @@ class JaxRsAnalyzerTask extends DefaultTask {
         project.jaxRsAnalyzer.backend.each {
             final Backend backend = JAXRSAnalyzer.constructBackend(it)
             backend.configure(config)
+            String outputFileBaseName = project.jaxRsAnalyzer.outputFileBaseName == null ? rest-resources : project.jaxRsAnalyzer.outputFileBaseName
             File outputFile = null
             switch (it) {
                 case 'swagger':
-                    outputFile = new File(outputDirectory, 'swagger.json')
+                    outputFile = new File(outputDirectory, outputFileBaseName + '-swagger.json')
                     break
                 case 'plaintext':
-                    outputFile = new File(outputDirectory, 'rest-resources.txt')
+                    outputFile = new File(outputDirectory, outputFileBaseName + '-plaintext.txt')
                     break
                 case 'asciidoc':
-                    outputFile = new File(outputDirectory, 'rest-resources.adoc')
+                    outputFile = new File(outputDirectory, outputFileBaseName + '-asciidoc.adoc')
                     break
             }
 


### PR DESCRIPTION
As in the title, changes done are:

- Support for 0.17 jaxrs-analyzer version
- "Implementation" type dependencies support
- output file basename support